### PR TITLE
Adapt code for new API 

### DIFF
--- a/BulletPhysics/BulletPhysics.cs
+++ b/BulletPhysics/BulletPhysics.cs
@@ -7,7 +7,7 @@ using VisualPinball.Unity.VPT.Table;
 
 namespace VisualPinball.Engine.Unity.BulletPhysics
 {
-	public class BulletPhysics : IPhysicsEngineNew
+	public class BulletPhysics : IPhysicsEngine
 	{
 		public string Name => "Bullet Physics";
 

--- a/BulletPhysics/BulletPhysics.cs
+++ b/BulletPhysics/BulletPhysics.cs
@@ -1,0 +1,79 @@
+using Unity.Entities;
+using Unity.Mathematics;
+using UnityEngine;
+using VisualPinball.Unity.Physics.DebugUI;
+using VisualPinball.Unity.Physics.Engine;
+using VisualPinball.Unity.VPT.Table;
+
+namespace VisualPinball.Engine.Unity.BulletPhysics
+{
+	public class BulletPhysics : IPhysicsEngineNew
+	{
+		public string Name => "Bullet Physics";
+
+		private readonly DebugFlipperSlider[] _flipperDebugSliders;
+		private BulletPhysicsComponent _component;
+
+		public BulletPhysics()
+		{
+			_flipperDebugSliders = new[] {
+				new DebugFlipperSlider("Acceleration", DebugFlipperSliderParam.Acc, 0.1f, 3.0f),
+				new DebugFlipperSlider("Mass (log10)", DebugFlipperSliderParam.Mass, -1.0f, 8.0f),
+				new DebugFlipperSlider("Off Scale", DebugFlipperSliderParam.OffScale, 0.01f, 1.0f),
+				new DebugFlipperSlider("On Near End Scale", DebugFlipperSliderParam.OnNearEndScale, 0.01f, 1.0f),
+				new DebugFlipperSlider("Num of degree near end", DebugFlipperSliderParam.NumOfDegreeNearEnd, 0.1f, 10.0f)
+			};
+		}
+
+		public void Init(TableBehavior tableBehavior)
+		{
+			// add component if not already added in editor
+			_component = tableBehavior.gameObject.GetComponent<BulletPhysicsComponent>();
+			if (_component == null) {
+				_component = tableBehavior.gameObject.AddComponent<BulletPhysicsComponent>();
+			}
+			_component.PrepareTable();
+		}
+
+		public Entity BallCreate(Mesh mesh, Material material, in float3 worldPos, in float3 localPos, in float3 localVel,
+			in float scale, in float mass, in float radius)
+		{
+			return _component.BallCreate(mesh, material, in worldPos, localPos, in localVel, in scale, in mass, in radius);
+		}
+
+		public void BallManualRoll(in Entity ballEntity, in float3 targetWorldPosition)
+		{
+			_component.ManualBallRoller(ballEntity, targetWorldPosition);
+		}
+
+		public void FlipperRotateToEnd(in Entity entity)
+		{
+			_component.OnRotateToStart(entity);
+		}
+
+		public void FlipperRotateToStart(in Entity entity)
+		{
+			_component.OnRotateToEnd(entity);
+		}
+
+		public DebugFlipperState[] FlipperGetDebugStates()
+		{
+			return PhyFlipper.GetFlipperStates();
+		}
+
+		public DebugFlipperSlider[] FlipperGetDebugSliders()
+		{
+			return _flipperDebugSliders;
+		}
+
+		public void SetFlipperDebugValue(DebugFlipperSliderParam param, float v)
+		{
+			_component.SetFloat(param, v);
+		}
+
+		public float GetFlipperDebugValue(DebugFlipperSliderParam param)
+		{
+			return _component.GetFloat(param);
+		}
+	}
+}

--- a/BulletPhysics/BulletPhysics.cs.meta
+++ b/BulletPhysics/BulletPhysics.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f4fa6b06d2da47ae86f39001c80dfc6b
+timeCreated: 1591196932

--- a/BulletPhysics/BulletPhysicsComponent.cs
+++ b/BulletPhysics/BulletPhysicsComponent.cs
@@ -83,7 +83,7 @@ namespace VisualPinball.Engine.Unity.BulletPhysics
         {
             base.OnDestroy();
         }
-        
+
 
         public void PrepareTable()
         {
@@ -141,7 +141,7 @@ namespace VisualPinball.Engine.Unity.BulletPhysics
                 float dist = (target - ballPos).Length * 0.05f;
                 _ballBodyForManualBallRoller.AngularVelocity = Vec3.Zero;
                 _ballBodyForManualBallRoller.LinearVelocity = Vec3.Zero;
-                if (dist > 20) 
+                if (dist > 20)
                     dist = 20;
                 if (dist > 0.1f)
                 {
@@ -234,7 +234,7 @@ namespace VisualPinball.Engine.Unity.BulletPhysics
                 phyBody.Mass,
                 flipper.data.Friction,
                 flipper.data.Elasticity * 100.0f);
-            
+
             var phyFlipperBehaviour = flipper.gameObject.AddComponent<PhyFlipperBehaviour>();
             phyFlipperBehaviour.motionStateView = phyBody.body.MotionState.ToView();
 #if UNITY_EDITOR
@@ -256,13 +256,13 @@ namespace VisualPinball.Engine.Unity.BulletPhysics
             Add(phyBody, entity, position);
 
             // last added ball is for manual ball roller
-            _ballBodyForManualBallRoller = phyBody.body; 
+            _ballBodyForManualBallRoller = phyBody.body;
         }
 
         // ==================================================================== === ===
 
         /// <summary>
-        /// Register flipper and add BulletPhysicsTransformData component to Entity        
+        /// Register flipper and add BulletPhysicsTransformData component to Entity
         /// </summary>
         internal class PhyFlipperBehaviour : MonoBehaviour, IConvertGameObjectToEntity
         {
@@ -275,8 +275,8 @@ namespace VisualPinball.Engine.Unity.BulletPhysics
 
             public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)
             {
-                if (EngineProvider<IDebugUINew>.Exists) {
-                    EngineProvider<IDebugUINew>.Get().OnRegisterFlipper(entity, Name);
+                if (EngineProvider<IDebugUI>.Exists) {
+                    EngineProvider<IDebugUI>.Get().OnRegisterFlipper(entity, Name);
                 }
 
                 PhyFlipper.OnRegiesterFlipper(entity, phyBody);

--- a/BulletPhysics/BulletPhysicsComponent.cs
+++ b/BulletPhysics/BulletPhysicsComponent.cs
@@ -1,24 +1,23 @@
-using System;
-using UnityEngine;
+using BulletSharp;
+using BulletSharp.Math;
 using Unity.Entities;
 using Unity.Mathematics;
-using VisualPinball.Unity.Game;
-using VisualPinball.Unity.VPT.Table;
+using UnityEngine;
+using VisualPinball.Engine.Common;
+using VisualPinball.Unity.Physics.DebugUI;
+using VisualPinball.Unity.VPT.Ball;
+using VisualPinball.Unity.VPT.Flipper;
 using VisualPinball.Unity.VPT.Primitive;
 using VisualPinball.Unity.VPT.Surface;
-using VisualPinball.Unity.VPT.Flipper;
-using VisualPinball.Unity.DebugAndPhysicsComunicationProxy;
-
+using VisualPinball.Unity.VPT.Table;
 using Vec3 = BulletSharp.Math.Vector3;
-using Matrix = BulletSharp.Math.Matrix;
-using SixLabors.ImageSharp.Processing.Processors.Dithering;
-using BulletSharp;
+using Vector3 = UnityEngine.Vector3;
 
 namespace VisualPinball.Engine.Unity.BulletPhysics
 {
     [AddComponentMenu("Visual Pinball/Bullet Physics Component")]
     [DisallowMultipleComponent]
-    public class BulletPhysicsComponent : BulletPhysicsHub, IPhysicsEngine
+    public class BulletPhysicsComponent : BulletPhysicsHub
     {
         // properties
         [SerializeField]
@@ -74,16 +73,6 @@ namespace VisualPinball.Engine.Unity.BulletPhysics
         }
 
         // ==================================================================== MonoBehaviour  ===
-        protected override void Awake()
-        {
-            base.Awake();
-            if (enabled)
-            {
-                // register Bullet Physics Engine
-                DPProxy.physicsEngine = this;
-                PrepareTable();
-            }
-        }
 
         protected void Update()
         {
@@ -124,13 +113,20 @@ namespace VisualPinball.Engine.Unity.BulletPhysics
 
         // ==================================================================== IPhysicsEngine ===
 
-        public void OnRegisterFlipper(Entity entity, string name) { /* flipper is registered with PhyFlipperBehaviour */}
-        public void OnPhysicsUpdate(int numSteps, float processingTime) { }
-        public void OnCreateBall(Entity entity, float3 position, float3 velocity, float radius, float mass) { AddBall(entity, position, velocity, radius, mass); }
-        public void OnRotateToEnd(Entity entity) { PhyFlipper.OnRotateToEnd(entity); }
-        public void OnRotateToStart(Entity entity) { PhyFlipper.OnRotateToStart(entity); }
-        public bool UsePureEntity() { return true; }
-        public void ManualBallRoller(Entity entity, float3 targetPosition)
+
+        public Entity BallCreate(Mesh mesh, Material material, in float3 worldPos, in float3 localPos, in float3 localVel,
+            in float scale, in float mass, in float radius)
+        {
+            var entity = BallManager.CreatePureEntity(mesh, material, worldPos, scale * radius * 2);
+            AddBall(entity, localPos, localVel, radius, mass);
+            return entity;
+        }
+
+        public void OnRotateToEnd(Entity entity) => PhyFlipper.OnRotateToEnd(entity);
+
+        public void OnRotateToStart(Entity entity) => PhyFlipper.OnRotateToStart(entity);
+
+        public void ManualBallRoller(in Entity entity, in float3 targetPosition)
         {
             // right now only last ball is affected
             if (_ballBodyForManualBallRoller != null)
@@ -155,26 +151,29 @@ namespace VisualPinball.Engine.Unity.BulletPhysics
             }
         }
 
-        public bool GetFlipperState(Entity entity, out FlipperState flipperState) { return PhyFlipper.GetFlipperState(entity, out flipperState); }
-        public float GetFloat(Params param) { return _GetParam(param); }
-        public void SetFloat(Params param, float val) { _GetParam(param) = val; }
+
+        public float GetFloat(DebugFlipperSliderParam param) => _GetParam(param);
+
+        public void SetFloat(DebugFlipperSliderParam param, float val) => _GetParam(param) = val;
 
         private float _dummyFloatParam = 0;
-        private ref float _GetParam(Params param)
+
+        private ref float _GetParam(DebugFlipperSliderParam param)
         {
             switch (param)
             {
-                case Params.Physics_FlipperAcc:
+                case DebugFlipperSliderParam.Acc:
                     return ref flipperAcceleration;
-                case Params.Physics_FlipperMass:
+                case DebugFlipperSliderParam.Mass:
                     return ref flipperMassMultiplierLog;
-                case Params.Physics_FlipperNumOfDegreeNearEnd:
+                case DebugFlipperSliderParam.NumOfDegreeNearEnd:
                     return ref flipperNumberOfDegreeNearEnd;
-                case Params.Physics_FlipperOffScale:
+                case DebugFlipperSliderParam.OffScale:
                     return ref flipperSolenoidOffAccelerationScale;
-                case Params.Physics_FlipperOnNearEndScale:
+                case DebugFlipperSliderParam.OnNearEndScale:
                     return ref flipperOnNearEndAccelerationScale;
             }
+
             return ref _dummyFloatParam;
         }
 
@@ -276,7 +275,10 @@ namespace VisualPinball.Engine.Unity.BulletPhysics
 
             public void Convert(Entity entity, EntityManager dstManager, GameObjectConversionSystem conversionSystem)
             {
-                DPProxy.OnRegisterFlipper(entity, Name);
+                if (EngineProvider<IDebugUINew>.Exists) {
+                    EngineProvider<IDebugUINew>.Get().OnRegisterFlipper(entity, Name);
+                }
+
                 PhyFlipper.OnRegiesterFlipper(entity, phyBody);
                 dstManager.AddComponentData(entity, new BulletPhysicsTransformData
                 {

--- a/BulletPhysics/BulletPhysicsComponent.cs
+++ b/BulletPhysics/BulletPhysicsComponent.cs
@@ -74,16 +74,15 @@ namespace VisualPinball.Engine.Unity.BulletPhysics
 
         // ==================================================================== MonoBehaviour  ===
 
+        protected override void Awake()
+        {
+            enabled = false; // will be enabled by BulletPhysics if this is the physics engine.
+        }
+
         protected void Update()
         {
             base.UpdatePhysics(GetTargetTime());
         }
-
-        protected override void OnDestroy()
-        {
-            base.OnDestroy();
-        }
-
 
         public void PrepareTable()
         {

--- a/BulletPhysics/BulletPhysicsHub.cs
+++ b/BulletPhysics/BulletPhysicsHub.cs
@@ -175,8 +175,8 @@ namespace VisualPinball.Engine.Unity.BulletPhysics
                     _physicsFrame += executedSteps;
                     --steps;
 
-                    if (EngineProvider<IDebugUINew>.Exists) {
-                        EngineProvider<IDebugUINew>.Get().OnPhysicsUpdate(1, (float)stopwatch.Elapsed.TotalMilliseconds);
+                    if (EngineProvider<IDebugUI>.Exists) {
+                        EngineProvider<IDebugUI>.Get().OnPhysicsUpdate(1, (float)stopwatch.Elapsed.TotalMilliseconds);
                     }
                 }
             }

--- a/BulletPhysics/BulletPhysicsHub.cs
+++ b/BulletPhysics/BulletPhysicsHub.cs
@@ -7,7 +7,8 @@ using VisualPinball.Unity.Game;
 using VisualPinball.Unity.VPT.Flipper;
 using VisualPinball.Unity.Physics.SystemGroup;
 using BulletSharp;
-
+using VisualPinball.Engine.Common;
+using VisualPinball.Unity.Physics.DebugUI;
 using Vector3 = BulletSharp.Math.Vector3;
 using Matrix = BulletSharp.Math.Matrix;
 using ECS_World = Unity.Entities.World;
@@ -174,7 +175,9 @@ namespace VisualPinball.Engine.Unity.BulletPhysics
                     _physicsFrame += executedSteps;
                     --steps;
 
-                    DPProxy.debugUI?.OnPhysicsUpdate(1, (float)stopwatch.Elapsed.TotalMilliseconds);
+                    if (EngineProvider<IDebugUINew>.Exists) {
+                        EngineProvider<IDebugUINew>.Get().OnPhysicsUpdate(1, (float)stopwatch.Elapsed.TotalMilliseconds);
+                    }
                 }
             }
         }

--- a/BulletPhysics/Phys/PhyFlipper.cs
+++ b/BulletPhysics/Phys/PhyFlipper.cs
@@ -5,7 +5,7 @@ using Unity.Mathematics;
 using VisualPinball.Unity.VPT.Flipper;
 using VisualPinball.Unity.Extensions;
 using BulletSharp;
-
+using VisualPinball.Unity.Physics.DebugUI;
 using Vector3 = BulletSharp.Math.Vector3;
 using Matrix = BulletSharp.Math.Matrix;
 
@@ -183,20 +183,19 @@ namespace VisualPinball.Engine.Unity.BulletPhysics
 
         public static void OnRotateToEnd(Entity entity) { _flippers[entity].SolenoidState = 1; }
         public static void OnRotateToStart(Entity entity) { _flippers[entity].SolenoidState = -1; }
-        public static bool GetFlipperState(Entity entity, out VisualPinball.Unity.DebugAndPhysicsComunicationProxy.FlipperState flipperState)
+
+        public static DebugFlipperState[] GetFlipperStates()
         {
-            bool ret = _flippers.ContainsKey(entity);
-            float angle = 0;
-            bool solenoid = false;
-            if (ret)
+            var states = new DebugFlipperState[_flippers.Count];
+            var i = 0;
+            foreach (var entity in _flippers.Keys)
             {
-                var phyFlipper = _flippers[entity];
-                angle = phyFlipper._GetAngle();
-                solenoid = phyFlipper.SolenoidState == 1;
+                var flipper = _flippers[entity];
+                states[i] = new DebugFlipperState(entity, flipper._GetAngle(), flipper.SolenoidState == 1);
+                i++;
             }
 
-            flipperState = new VisualPinball.Unity.DebugAndPhysicsComunicationProxy.FlipperState(angle, solenoid);
-            return ret;
+            return states;
         }
 
         public static void OnRegiesterFlipper(Entity entity, PhyFlipper phyBody)


### PR DESCRIPTION
This PR updates the repo to work with ravarcade/VisualPinball.Engine#3.

Like in the other PR, bootstrapping has changed as well. Instead of the component implementing `IPhysicsEngine`, we now have a small class `BulletPhysics` instantiated by `EngineProvider` that adds the component if not already added. The component can be added to the table in the editor but will stay disabled if the table's physics engine is not set to Bullet.

I must admit I haven't tested this yet. It compiles and it should, but there might be bugs. ;)
